### PR TITLE
fix: fixed custom fetch config

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ In the following example we'll add a token to each fetch request that our Client
 />
 ```
 
+#### `fetchOptions`
+
+This attribute allows you to pass extra options to the fetch function.
+
 #### `requestPolicy`
 
 Set the default cache policy. The default is "cache-first".

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class {
   </@then>
   <@placeholder>
     <spinner />
-  <@placeholder>
+  </@placeholder>
 </gql-query>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@marko/graphql",
+  "name": "@marko/urql",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@marko/graphql",
+      "name": "@marko/urql",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -35,6 +35,7 @@
         "esbuild-register": "^3.0.0",
         "eslint": "^8.1.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-formatter-codeframe": "^7.32.1",
         "express": "^4.17.1",
         "express-graphql": "0.12.0",
         "fast-glob": "^3.2.7",
@@ -3794,6 +3795,28 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-formatter-codeframe": {
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-codeframe/-/eslint-formatter-codeframe-7.32.1.tgz",
+      "integrity": "sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "7.12.11",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/eslint-formatter-codeframe/node_modules/@babel/code-frame": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/eslint-scope": {
@@ -16149,6 +16172,27 @@
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-formatter-codeframe": {
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-codeframe/-/eslint-formatter-codeframe-7.32.1.tgz",
+      "integrity": "sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.12.11",
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        }
+      }
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "esbuild-register": "^3.0.0",
     "eslint": "^8.1.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-formatter-codeframe": "^7.32.1",
     "express": "^4.17.1",
     "express-graphql": "0.12.0",
     "fast-glob": "^3.2.7",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -26,8 +26,8 @@ export function createClient({
       ssr, // Add `ssr` in front of the `fetchExchange`
       fetchExchange,
     ],
-    ...lookup.config,
     fetch,
+    ...lookup.config,
   });
 
   return { client, ssr };

--- a/src/components/gql-client/marko-tag.json
+++ b/src/components/gql-client/marko-tag.json
@@ -28,7 +28,7 @@
     "type": "object",
     "autocomplete": [
       {
-        "description": "Additional fetchOptions that fetch should use to make a request"
+        "description": "Additional fetch options that fetch should use to make a request"
       }
     ]
   },

--- a/src/components/gql-client/marko-tag.json
+++ b/src/components/gql-client/marko-tag.json
@@ -24,6 +24,14 @@
       }
     ]
   },
+  "@fetchOptions": {
+    "type": "object",
+    "autocomplete": [
+      {
+        "description": "Additional fetchOptions that fetch should use to make a request"
+      }
+    ]
+  },
   "@requestPolicy": {
     "enum": ["cache-first", "cache-and-network", "network-only", "cache-only"],
     "autocomplete": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Right now if i specify a custom fetch function for the `gql-client` tag, it's being overwritten by the node-fetch.

Also, the ability to enhance fetchOptions is missing. Adding the tag argument.

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

I need to be able to provide the custom fetch function, especially for the server-side to have a corporate specific fetcher.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
resolves https://github.com/marko-js/urql/issues/2

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
