### PR TITLE
fix: improve Marko 4 support

### DIFF
--- a/src/components/gql-client/index.marko
+++ b/src/components/gql-client/index.marko
@@ -4,3 +4,5 @@ class {
     lookup.config = input;
   }
 }
+
+<!-- -->

--- a/src/components/gql-query/index.marko
+++ b/src/components/gql-query/index.marko
@@ -1,3 +1,3 @@
-import component from "./impl"
+import Template from "./impl"
 
-<${component} ...input/>
+<${Template} ...input/>


### PR DESCRIPTION
## Description

Fixes two issues blocking Marko 4 support.

1. Marko 4 doesn't like components which only contain a `class`, so we have to add an empty comment...
2. `component` is a reserved global in Marko 4 so we use a different variable name.
