### PR TITLE
fix: forward headers when fetching from server

### DIFF
--- a/src/components/gql-query/impl/server.marko
+++ b/src/components/gql-query/impl/server.marko
@@ -1,9 +1,23 @@
-import fetch from "make-fetch-happen";
+import fetchImpl from "make-fetch-happen";
 import { createClient } from "../../../client";
 $ {
   let store =
     out.global.$$GQL ||
-    (out.global.$$GQL = createClient({ fetch, isServer: true }));
+    (out.global.$$GQL = createClient({
+      isServer: true,
+      fetch(url, options) {
+        const incomingMessage = out.stream && (out.stream.req || out.stream.request) || out.global.req || out.global.request;
+        if (!incomingMessage) return fetchImpl(url, options);
+
+        return fetchImpl(url, {
+          ...options,
+          headers: {
+            ...incomingMessage.headers,
+            ...options.headers,
+          }
+        });
+      }
+    }));
   const request = store.client.query(input.query, input.variables).toPromise();
 }
 


### PR DESCRIPTION
## Description

The client side implementation of this module has always forwarded headers,
this PR now forwards those headers when the request is made from the server also by default.

This is particularly useful for auth purposes.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
