### PR TITLE
Consistency improvements and refactoring

### DIFF
--- a/src/components/gql-mutation/__tests__/__snapshots__/mutation-with-query/renders.expected/loading.0.html
+++ b/src/components/gql-mutation/__tests__/__snapshots__/mutation-with-query/renders.expected/loading.0.html
@@ -1,7 +1,9 @@
-<span
-  id="GENERATED-0"
->
-  <span>
-    Loading Messages
+<div>
+  <span
+    id="GENERATED-0"
+  >
+    <span>
+      Loading Messages
+    </span>
   </span>
-</span>
+</div>

--- a/src/components/gql-mutation/__tests__/__snapshots__/mutation-with-query/renders.expected/loading.1.html
+++ b/src/components/gql-mutation/__tests__/__snapshots__/mutation-with-query/renders.expected/loading.1.html
@@ -1,20 +1,20 @@
-<span
-  id="GENERATED-0"
->
-  <span>
-    Loading Messages
+<div>
+  <span
+    id="GENERATED-0"
+  >
+    <span>
+      Loading Messages
+    </span>
   </span>
-</span>
+</div>
 <div
   id="GENERATED-1"
   style="display:none"
 >
-  <div>
-    <h1>
-      Messages
-    </h1>
-    <button>
-      Add
-    </button>
-  </div>
+  <h1>
+    Messages
+  </h1>
+  <button>
+    Add
+  </button>
 </div>

--- a/src/components/gql-mutation/index.marko
+++ b/src/components/gql-mutation/index.marko
@@ -4,17 +4,14 @@ class {
     this.state = { results: {}, fetching: false };
   }
 }
+$ const { renderBody, mutation, requestPolicy } = input;
 
-<${input.renderBody}(
+<${renderBody}(
   (variables, options) => {
     const { client } = window.$$GQL || (window.$$GQL = createClient({}));
     state.fetching = true;
     return client
-      .mutation(input.mutation, variables, {
-        ...input.context,
-        requestPolicy: input.requestPolicy,
-        ...options,
-      })
+      .mutation(mutation, variables, { requestPolicy, ...options })
       .toPromise()
       .then((results) => {
         state.results = results;

--- a/src/components/gql-query/__tests__/__snapshots__/isomorphic-placeholder/renders.expected/loading.0.html
+++ b/src/components/gql-query/__tests__/__snapshots__/isomorphic-placeholder/renders.expected/loading.0.html
@@ -1,7 +1,9 @@
-<span
-  id="GENERATED-0"
->
-  <span>
-    Loading...
+<div>
+  <span
+    id="GENERATED-0"
+  >
+    <span>
+      Loading...
+    </span>
   </span>
-</span>
+</div>

--- a/src/components/gql-query/__tests__/__snapshots__/isomorphic-placeholder/renders.expected/loading.1.html
+++ b/src/components/gql-query/__tests__/__snapshots__/isomorphic-placeholder/renders.expected/loading.1.html
@@ -1,17 +1,17 @@
-<span
-  id="GENERATED-0"
->
-  <span>
-    Loading...
+<div>
+  <span
+    id="GENERATED-0"
+  >
+    <span>
+      Loading...
+    </span>
   </span>
-</span>
+</div>
 <div
   id="GENERATED-1"
   style="display:none"
 >
-  <div>
-    <span>
-      Hello world!
-    </span>
-  </div>
+  <span>
+    Hello world!
+  </span>
 </div>

--- a/src/components/gql-query/__tests__/__snapshots__/isomorphic-variables/renders.expected/loading.0.html
+++ b/src/components/gql-query/__tests__/__snapshots__/isomorphic-variables/renders.expected/loading.0.html
@@ -1,3 +1,5 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>

--- a/src/components/gql-query/__tests__/__snapshots__/isomorphic-variables/renders.expected/loading.1.html
+++ b/src/components/gql-query/__tests__/__snapshots__/isomorphic-variables/renders.expected/loading.1.html
@@ -1,13 +1,13 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>
 <div
   id="GENERATED-1"
   style="display:none"
 >
-  <div>
-    <span>
-      Hello John!
-    </span>
-  </div>
+  <span>
+    Hello John!
+  </span>
 </div>

--- a/src/components/gql-query/__tests__/__snapshots__/isomorphic/renders.expected/loading.0.html
+++ b/src/components/gql-query/__tests__/__snapshots__/isomorphic/renders.expected/loading.0.html
@@ -1,3 +1,5 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>

--- a/src/components/gql-query/__tests__/__snapshots__/isomorphic/renders.expected/loading.1.html
+++ b/src/components/gql-query/__tests__/__snapshots__/isomorphic/renders.expected/loading.1.html
@@ -1,13 +1,13 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>
 <div
   id="GENERATED-1"
   style="display:none"
 >
-  <div>
-    <span>
-      Hello world!
-    </span>
-  </div>
+  <span>
+    Hello world!
+  </span>
 </div>

--- a/src/components/gql-query/__tests__/__snapshots__/request-policy/renders.expected/loading.0.html
+++ b/src/components/gql-query/__tests__/__snapshots__/request-policy/renders.expected/loading.0.html
@@ -1,3 +1,5 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>

--- a/src/components/gql-query/__tests__/__snapshots__/request-policy/renders.expected/loading.1.html
+++ b/src/components/gql-query/__tests__/__snapshots__/request-policy/renders.expected/loading.1.html
@@ -1,16 +1,16 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>
 <div
   id="GENERATED-1"
   style="display:none"
 >
-  <div>
-    <span>
-      Hello John!
-    </span>
-    <button>
-      Toggle
-    </button>
-  </div>
+  <span>
+    Hello John!
+  </span>
+  <button>
+    Toggle
+  </button>
 </div>

--- a/src/components/gql-query/__tests__/__snapshots__/server-only-placeholder/renders.expected/loading.0.html
+++ b/src/components/gql-query/__tests__/__snapshots__/server-only-placeholder/renders.expected/loading.0.html
@@ -1,7 +1,9 @@
-<span
-  id="GENERATED-0"
->
-  <span>
-    Loading...
+<div>
+  <span
+    id="GENERATED-0"
+  >
+    <span>
+      Loading...
+    </span>
   </span>
-</span>
+</div>

--- a/src/components/gql-query/__tests__/__snapshots__/server-only-placeholder/renders.expected/loading.1.html
+++ b/src/components/gql-query/__tests__/__snapshots__/server-only-placeholder/renders.expected/loading.1.html
@@ -1,17 +1,17 @@
-<span
-  id="GENERATED-0"
->
-  <span>
-    Loading...
+<div>
+  <span
+    id="GENERATED-0"
+  >
+    <span>
+      Loading...
+    </span>
   </span>
-</span>
+</div>
 <div
   id="GENERATED-1"
   style="display:none"
 >
-  <div>
-    <span>
-      Hello world!
-    </span>
-  </div>
+  <span>
+    Hello world!
+  </span>
 </div>

--- a/src/components/gql-query/__tests__/__snapshots__/server-only-variables/renders.expected/loading.0.html
+++ b/src/components/gql-query/__tests__/__snapshots__/server-only-variables/renders.expected/loading.0.html
@@ -1,3 +1,5 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>

--- a/src/components/gql-query/__tests__/__snapshots__/server-only-variables/renders.expected/loading.1.html
+++ b/src/components/gql-query/__tests__/__snapshots__/server-only-variables/renders.expected/loading.1.html
@@ -1,13 +1,13 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>
 <div
   id="GENERATED-1"
   style="display:none"
 >
-  <div>
-    <span>
-      Hello John!
-    </span>
-  </div>
+  <span>
+    Hello John!
+  </span>
 </div>

--- a/src/components/gql-query/__tests__/__snapshots__/server-only/renders.expected/loading.0.html
+++ b/src/components/gql-query/__tests__/__snapshots__/server-only/renders.expected/loading.0.html
@@ -1,3 +1,5 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>

--- a/src/components/gql-query/__tests__/__snapshots__/server-only/renders.expected/loading.1.html
+++ b/src/components/gql-query/__tests__/__snapshots__/server-only/renders.expected/loading.1.html
@@ -1,13 +1,13 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>
 <div
   id="GENERATED-1"
   style="display:none"
 >
-  <div>
-    <span>
-      Hello world!
-    </span>
-  </div>
+  <span>
+    Hello world!
+  </span>
 </div>

--- a/src/components/gql-query/__tests__/__snapshots__/update-variables/renders.expected/loading.0.html
+++ b/src/components/gql-query/__tests__/__snapshots__/update-variables/renders.expected/loading.0.html
@@ -1,3 +1,5 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>

--- a/src/components/gql-query/__tests__/__snapshots__/update-variables/renders.expected/loading.1.html
+++ b/src/components/gql-query/__tests__/__snapshots__/update-variables/renders.expected/loading.1.html
@@ -1,16 +1,16 @@
-<noscript
-  id="GENERATED-0"
-/>
+<div>
+  <noscript
+    id="GENERATED-0"
+  />
+</div>
 <div
   id="GENERATED-1"
   style="display:none"
 >
-  <div>
-    <span>
-      Hello John!
-    </span>
-    <button>
-      Toggle
-    </button>
-  </div>
+  <span>
+    Hello John!
+  </span>
+  <button>
+    Toggle
+  </button>
 </div>

--- a/src/components/gql-query/components/gql-query-client/index.marko
+++ b/src/components/gql-query/components/gql-query-client/index.marko
@@ -1,55 +1,57 @@
 import { pipe, subscribe } from "wonka";
 import readyLookup from "../../ready-lookup";
-
-static function doQuery(component, input, options = {}) {
+static function doQuery(
+  component,
+  { query, variables, requestPolicy },
+  options
+) {
   if (component.unsubscribe) {
     component.unsubscribe();
     component.unsubscribe = null;
   }
-  if (component.results) component.results.fetching = true;
+
+  component.state.fetching = true;
   component.unsubscribe = pipe(
-    component.store.client.query(input.query, input.variables, {
-      ...input.context,
-      requestPolicy: input.requestPolicy,
+    window.$$GQL.client.query(query, variables, {
+      requestPolicy,
       ...options,
     }),
-    subscribe((results) => {
-      component.results = results;
-      component.results.fetching = false;
-      component.forceUpdate();
+    subscribe(({ data, error }) => {
+      component.state.data = data;
+      component.state.error = error;
+      component.state.fetching = false;
     })
   ).unsubscribe;
 }
 class {
-  onCreate({ data }) {
-    data && (this.results = { data });
+  onCreate({ data, error, opKey }) {
+    this.state = { data, error, fetching: false };
+
+    if (typeof document !== "undefined" && opKey) {
+      window.$$GQL.ssr.restoreData({
+        [opKey]: {
+          data: data ? JSON.stringify(data) : undefined,
+          error,
+        },
+      });
+      readyLookup[this.id]();
+    }
   }
   onInput(input) {
-    if (typeof window !== "undefined") {
-      this.store = window.$$GQL;
-
-      if ("opKey" in input) {
-        this.store.ssr.restoreData({
-          [input.opKey]: { data: JSON.stringify(input.data) },
-        });
-        readyLookup[this.id]();
-      } else doQuery(this, input);
-    }
+    if (!input.opKey) doQuery(this, input);
   }
   onDestroy() {
     this.unsubscribe && this.unsubscribe();
   }
 }
 
-<if(component.results)>
-  <${input.then.renderBody}(
-    component.results,
-    (options = {}) => {
-      doQuery(component, input, { requestPolicy: "network-only", ...options });
-      component.forceUpdate();
-    },
+<if(state.data || state.error)>
+  <${input.then}(
+    state,
+    (options) =>
+      doQuery(component, input, { requestPolicy: "network-only", ...options }),
   )/>
 </if>
-<else-if(input.placeholder)>
-  <${input.placeholder.renderBody}/>
-</else-if>
+<else>
+  <${input.placeholder}/>
+</else>

--- a/src/components/gql-query/impl/browser.marko
+++ b/src/components/gql-query/impl/browser.marko
@@ -2,11 +2,15 @@ import readyLookup from "../ready-lookup";
 import { createClient } from "../../../client";
 $ window.$$GQL || (window.$$GQL = createClient({}));
 
-<div no-update-if(!component.ready)>
+<div key="root" no-update-if(!component.ready)>
   $ component.ready = true;
   <gql-query-client
     key="gqlc"
-    ...input
+    query=input.query
+    variables=input.variables
+    requestPolicy=input.requestPolicy
+    then=input.then
+    placeholder=input.placeholder
   />
 </div>
 $ if (!component.ready) {

--- a/src/components/gql-query/impl/server.marko
+++ b/src/components/gql-query/impl/server.marko
@@ -1,7 +1,7 @@
 import fetchImpl from "make-fetch-happen";
 import { createClient } from "../../../client";
 $ {
-  let store =
+  const store =
     out.global.$$GQL ||
     (out.global.$$GQL = createClient({
       isServer: true,
@@ -18,23 +18,24 @@ $ {
         });
       }
     }));
-  const request = store.client.query(input.query, input.variables).toPromise();
 }
-
-<await(request) client-reorder placeholder=input.placeholder>
-  <@then|result|>
-    <component-def/>
-    <div no-update>
+<div key="root" no-update>
+  <await(store.client.query(input.query, input.variables).toPromise())
+    client-reorder
+    placeholder=input.placeholder
+  >
+    <@then|{ data, error, operation }|>
+      <component-def/>
       <if(componentDef._wrr)>
         <gql-query-client
-          data=result.data
-          op-key=result.operation.key
-          then=input.then
           key="gqlc"
+          data=data
+          error=error
+          opKey=operation.key
+          then=input.then
         />
       </if>
-      <else><${input.then.renderBody} data=result.data/></else>
-    </div>
-  </@then>
-</await>
-
+      <else><${input.then}({ data, error, fetching: false })/></else>
+    </@then>
+  </await>
+</div>

--- a/src/components/gql-query/impl/server.marko
+++ b/src/components/gql-query/impl/server.marko
@@ -6,17 +6,26 @@ $ {
     (out.global.$$GQL = createClient({
       isServer: true,
       fetch(url, options) {
-        const incomingMessage = out.stream && (out.stream.req || out.stream.request) || out.global.req || out.global.request;
+        const incomingMessage =
+          (out.stream && (out.stream.req || out.stream.request)) ||
+          out.global.req ||
+          out.global.request;
         if (!incomingMessage) return fetchImpl(url, options);
 
-        return fetchImpl(url, {
-          ...options,
-          headers: {
-            ...incomingMessage.headers,
-            ...options.headers,
+        return fetchImpl(
+          new URL(
+            url,
+            `${incomingMessage.protocol}://${incomingMessage.headers.host}`
+          ).toString(),
+          {
+            ...options,
+            headers: {
+              ...incomingMessage.headers,
+              ...options.headers,
+            },
           }
-        });
-      }
+        );
+      },
     }));
 }
 <div key="root" no-update>


### PR DESCRIPTION
## Description

* Supports a relative url for the default fetch implementation in SSR mode (means you should be able to use a relative url for the `gql-client` and it'll be resolved relative to the current request).
* Placeholders are now rendered inside a wrapper div on **both** the server and the browser (previously only the browser renderer had the wrapper).
* `error` is now properly serialized and passed in for both ssr and csr modes.

Other refactoring and cleaning.
