### PR TITLE
fix: honor NODE_TLS_REJECT_UNAUTHORIZED env var

### DIFF
--- a/src/components/gql-query/impl/server.marko
+++ b/src/components/gql-query/impl/server.marko
@@ -1,5 +1,7 @@
 import fetchImpl from "make-fetch-happen";
 import { createClient } from "../../../client";
+static const strictSSL = process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0";
+
 $ {
   const store =
     out.global.$$GQL ||
@@ -19,6 +21,7 @@ $ {
           ).toString(),
           {
             ...options,
+            strictSSL,
             headers: {
               ...incomingMessage.headers,
               ...options.headers,


### PR DESCRIPTION
## Description

Forwards the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable to the default SSR fetch implementation (allows working with dev mode self signed ssl certs).
