### PR TITLE
fix: update state when calling mutate

### DIFF
--- a/src/components/gql-mutation/__tests__/__snapshots__/run-mutation/renders.expected/step-0.0.html
+++ b/src/components/gql-mutation/__tests__/__snapshots__/run-mutation/renders.expected/step-0.0.html
@@ -1,0 +1,10 @@
+<h1>
+  Messages
+</h1>
+<span />
+<span>
+  executing
+</span>
+<button>
+  Add
+</button>

--- a/src/components/gql-mutation/__tests__/__snapshots__/run-mutation/renders.expected/step-0.1.html
+++ b/src/components/gql-mutation/__tests__/__snapshots__/run-mutation/renders.expected/step-0.1.html
@@ -1,0 +1,10 @@
+<h1>
+  Messages
+</h1>
+<span>
+  Hello
+</span>
+<span />
+<button>
+  Add
+</button>

--- a/src/components/gql-mutation/index.marko
+++ b/src/components/gql-mutation/index.marko
@@ -9,13 +9,15 @@ $ const { renderBody, mutation, requestPolicy } = input;
 <${renderBody}(
   (variables, options) => {
     const { client } = window.$$GQL || (window.$$GQL = createClient({}));
-    state.fetching = true;
+    component.setState("fetching", true);
     return client
       .mutation(mutation, variables, { requestPolicy, ...options })
       .toPromise()
       .then((results) => {
-        state.results = results;
-        state.fetching = false;
+        component.setState({
+          results,
+          fetching: false,
+        });
         return results;
       });
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Calling mutate for gql-mutation is not updating state for `fetching` and response from mutate.

## Description

Apply `state` to a component as a setter is not affecting component state because `component.state` is not an instance of `State`. So to update a state from template we need to call `component.setState`.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.