### PR TITLE
fix: on mount double request

### DIFF
--- a/src/components/gql-query/components/gql-query-client/index.marko
+++ b/src/components/gql-query/components/gql-query-client/index.marko
@@ -27,7 +27,10 @@ class {
         this.on("render", onRender);
         ready();
       } else {
-        this.once("mount", () => this.doQuery());
+        this.once("mount", () => {
+          this.shouldQuery = false;
+          this.doQuery();
+        });
       }
     }
 


### PR DESCRIPTION
Fix for double `doQuery` on mount.

## Description

`doQuery` is called twice on mount component, this happens after `doQuery` is applying result to state witch will trigger `onUpdate` method.  On input property `shouldQuery` is set to true but is not updated to false before calling `doQuery`