### PR TITLE
fix: avoid require for devtools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+package-lock.json -diff
+src/node_modules/** linguist-generated=false

--- a/src/__tests__/alias-virtual-modules.ts
+++ b/src/__tests__/alias-virtual-modules.ts
@@ -4,6 +4,9 @@ import { Module } from "module";
 // For our browser remapped modules we skip resolution during testing and resolve the original source files.
 const modules: Record<string, string> = {
   "@internal/client": path.resolve("src/node_modules/@internal/client/node.ts"),
+  "@internal/client/devtools": path.resolve(
+    "src/node_modules/@internal/client/devtools.ts",
+  ),
   "@internal/gql-query": path.resolve(
     "src/node_modules/@internal/gql-query/node.marko",
   ),

--- a/src/__tests__/build/index.ts
+++ b/src/__tests__/build/index.ts
@@ -21,6 +21,10 @@ export default async function (file: string) {
         cwd,
         "src/node_modules/@internal/client/browser.ts",
       ),
+      "@internal/client/devtools": path.join(
+        cwd,
+        "src/node_modules/@internal/client/devtools.ts",
+      ),
       "@internal/gql-query": path.join(
         cwd,
         "src/node_modules/@internal/gql-query/browser.marko",

--- a/src/node_modules/@internal/client/browser.ts
+++ b/src/node_modules/@internal/client/browser.ts
@@ -8,6 +8,8 @@ import {
   type Client,
 } from "@urql/core";
 
+import { devtoolsExchange } from "@internal/client/devtools";
+
 let client: Client;
 let ssr: ReturnType<typeof ssrExchange>;
 
@@ -22,8 +24,7 @@ export function configureClient(config: ClientOptions) {
   ssr = ssrExchange({ isClient: true });
   let exchanges = [dedupExchange, cacheExchange, ssr, fetchExchange];
   if (process.env.NODE_ENV !== "production") {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    exchanges.push(require("@urql/devtools").devtoolsExchange);
+    exchanges.push(devtoolsExchange);
   }
 
   if (config.exchanges) {

--- a/src/node_modules/@internal/client/devtools-prod.ts
+++ b/src/node_modules/@internal/client/devtools-prod.ts
@@ -1,0 +1,1 @@
+export const devtoolsExchange = undefined;

--- a/src/node_modules/@internal/client/devtools.ts
+++ b/src/node_modules/@internal/client/devtools.ts
@@ -1,0 +1,1 @@
+export { devtoolsExchange } from "@urql/devtools";

--- a/src/node_modules/@internal/client/node.ts
+++ b/src/node_modules/@internal/client/node.ts
@@ -12,6 +12,8 @@ import {
 const kClient = Symbol("client");
 const strictSSL = process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0";
 
+export const readyLookup = {};
+
 export function getClient(out: any): Client {
   const client = out.global[kClient];
   if (!client) throw new Error("<gql-client> not configured.");

--- a/src/node_modules/@internal/client/package.json
+++ b/src/node_modules/@internal/client/package.json
@@ -12,6 +12,16 @@
         "import": "./node.mjs",
         "default": "./node.js"
       }
+    },
+    "./devtools": {
+      "development": {
+        "import": "./devtools.mjs",
+        "default": "./devtools.js"
+      },
+      "default": {
+        "import": "./devtools-prod.mjs",
+        "default": "./devtools-prod.js"
+      }
     }
   }
 }


### PR DESCRIPTION
* Avoid using `require` to load devtools, instead rely on export conditions.
* Ensure ssr internal client exposes ready lookup.